### PR TITLE
Switch from low-level Parquet API to Arrow Parquet API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "pcap-to-parquet"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arrow-array = "50.0.0"
 parquet = "50.0.0"
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use libpcap::ffi;
 struct Packet {
     src_ip: Option<String>,
     dst_ip: Option<String>,
-    mm_ts: i64,
-    mm_id: u16,
-    mm_port: u8,
+    mm_ts: Option<i64>,
+    mm_id: Option<u16>,
+    mm_port: Option<u8>,
 }
 
 impl Packet {
@@ -127,9 +127,9 @@ fn parse_metamako_trailer(packet: &[u8], packet_fields: &mut Packet, pcap_ts: i6
     ]);
 
     if i64::abs(pcap_ts - mm_s as i64) < 5 * 60 && mm_ns < 1_000_000_000 {
-        packet_fields.mm_id = u16::from_be_bytes([packet[len - 7], packet[len - 6]]);
-        packet_fields.mm_port = u8::from_be_bytes([packet[len - 5]]);
-        packet_fields.mm_ts = mm_s as i64 * 10i64.pow(9) + mm_ns as i64;
+        packet_fields.mm_id = Some(u16::from_be_bytes([packet[len - 7], packet[len - 6]]));
+        packet_fields.mm_port = Some(u8::from_be_bytes([packet[len - 5]]));
+        packet_fields.mm_ts = Some(mm_s as i64 * 10i64.pow(9) + mm_ns as i64);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@ use libpcap::ffi;
 
 /// Simple representation of the information
 /// that we want to extract from a packet
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Clone)]
 struct Packet {
-    src_ip: Option<std::net::IpAddr>,
-    dst_ip: Option<std::net::IpAddr>,
+    src_ip: Option<String>,
+    dst_ip: Option<String>,
     mm_ts: i64,
     mm_id: u16,
     mm_port: u8,
@@ -17,44 +17,28 @@ impl Packet {
         Default::default()
     }
 
-    /// Returns hardcoded parquet schema definition
-    fn get_parquet_schema() -> String {
-        String::from(
-            "message Packet {
-                required binary src_ip  (UTF8);
-                required binary dst_ip  (UTF8);
-                required int64  mm_ts;
-                required int32  mm_id   (UINT_16);
-                required int32  mm_port (UINT_8);
-            }",
-        )
-    }
-
     /// Serializes the struct into row representation for parquet file
-    fn serialize(&self) -> Vec<PacketField> {
-        let mut ser_vec = Vec::new();
-        match self.src_ip {
-            Some(x) => ser_vec.push(PacketField::Text(x.to_string())),
-            None => ser_vec.push(PacketField::Text("".to_string())),
-        }
-        match self.dst_ip {
-            Some(x) => ser_vec.push(PacketField::Text(x.to_string())),
-            None => ser_vec.push(PacketField::Text("".to_string())),
-        }
-        ser_vec.push(PacketField::Int64(self.mm_ts));
-        ser_vec.push(PacketField::Int32(self.mm_id as i32));
-        ser_vec.push(PacketField::Int32(self.mm_port as i32));
+    fn serialize(self) -> arrow_array::RecordBatch {
+        let src_ip: arrow_array::ArrayRef =
+            std::sync::Arc::new(arrow_array::StringArray::from(vec![self.src_ip]));
+        let dst_ip: arrow_array::ArrayRef =
+            std::sync::Arc::new(arrow_array::StringArray::from(vec![self.dst_ip]));
+        let mm_ts: arrow_array::ArrayRef =
+            std::sync::Arc::new(arrow_array::Int64Array::from(vec![self.mm_ts]));
+        let mm_id: arrow_array::ArrayRef =
+            std::sync::Arc::new(arrow_array::UInt16Array::from(vec![self.mm_id]));
+        let mm_port: arrow_array::ArrayRef =
+            std::sync::Arc::new(arrow_array::UInt8Array::from(vec![self.mm_port]));
 
-        return ser_vec;
+        arrow_array::RecordBatch::try_from_iter(vec![
+            ("src_ip", src_ip),
+            ("dst_ip", dst_ip),
+            ("mm_ts", mm_ts),
+            ("mm_id", mm_id),
+            ("mm_port", mm_port),
+        ])
+        .unwrap()
     }
-}
-
-/// All desired packet fields can be represented
-/// with these 3 types in a parquet schema
-enum PacketField {
-    Text(String),
-    Int32(i32),
-    Int64(i64),
 }
 
 fn main() {
@@ -79,8 +63,7 @@ fn main() {
     }
 
     // parquet file setup
-    let schema =
-        parquet::schema::parser::parse_message_type(&Packet::get_parquet_schema()).unwrap();
+    let schema = Packet::serialize(Packet::new()).schema();
 
     let props = parquet::file::properties::WriterProperties::builder()
         .set_compression(parquet::basic::Compression::ZSTD(
@@ -90,9 +73,7 @@ fn main() {
 
     let path = std::path::Path::new(output_path.as_str());
     let file = std::fs::File::create(path).unwrap();
-    let mut writer =
-        parquet::file::writer::SerializedFileWriter::new(file, schema.into(), props.into())
-            .unwrap();
+    let mut writer = parquet::arrow::ArrowWriter::try_new(file, schema, Some(props)).unwrap();
 
     // loop over packets in pcap file
     loop {
@@ -148,7 +129,6 @@ fn parse_metamako_trailer(packet: &[u8], packet_fields: &mut Packet, pcap_ts: i6
     if i64::abs(pcap_ts - mm_s as i64) < 5 * 60 && mm_ns < 1_000_000_000 {
         packet_fields.mm_id = u16::from_be_bytes([packet[len - 7], packet[len - 6]]);
         packet_fields.mm_port = u8::from_be_bytes([packet[len - 5]]);
-
         packet_fields.mm_ts = mm_s as i64 * 10i64.pow(9) + mm_ns as i64;
     }
 }
@@ -161,18 +141,24 @@ fn parse_ipv4_packet(packet: &[u8], packet_fields: &mut Packet) {
     let src_addr = &packet[12..16];
     let dst_addr = &packet[16..20];
 
-    packet_fields.src_ip = Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-        src_addr[0],
-        src_addr[1],
-        src_addr[2],
-        src_addr[3],
-    )));
-    packet_fields.dst_ip = Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-        dst_addr[0],
-        dst_addr[1],
-        dst_addr[2],
-        dst_addr[3],
-    )));
+    packet_fields.src_ip = Some(
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+            src_addr[0],
+            src_addr[1],
+            src_addr[2],
+            src_addr[3],
+        ))
+        .to_string(),
+    );
+    packet_fields.dst_ip = Some(
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+            dst_addr[0],
+            dst_addr[1],
+            dst_addr[2],
+            dst_addr[3],
+        ))
+        .to_string(),
+    );
 }
 
 /// Assuming Ethernet II frame format (14 bytes header)
@@ -201,48 +187,10 @@ fn parse_ethernet_frame(packet: &[u8], packet_fields: &mut Packet) {
 }
 
 fn write_packet_to_parquet<W: std::io::Write>(
-    packet_vec: Vec<PacketField>,
-    writer: &mut parquet::file::writer::SerializedFileWriter<W>,
+    packet_record: arrow_array::RecordBatch,
+    writer: &mut parquet::arrow::ArrowWriter<W>,
 ) where
     W: Send,
 {
-    // get row group writer
-    let mut row_group_writer = writer.next_row_group().unwrap();
-    for field in packet_vec.iter() {
-        match field {
-            PacketField::Text(text) => {
-                if let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
-                    col_writer
-                        .typed::<parquet::data_type::ByteArrayType>()
-                        .write_batch(
-                            &[parquet::data_type::ByteArray::from(text.as_bytes())],
-                            None,
-                            None,
-                        )
-                        .unwrap();
-                    col_writer.close().unwrap();
-                }
-            }
-            PacketField::Int64(i) => {
-                if let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
-                    col_writer
-                        .typed::<parquet::data_type::Int64Type>()
-                        .write_batch(&[*i], None, None)
-                        .unwrap();
-                    col_writer.close().unwrap();
-                }
-            }
-            PacketField::Int32(i) => {
-                if let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
-                    col_writer
-                        .typed::<parquet::data_type::Int32Type>()
-                        .write_batch(&[*i], None, None)
-                        .unwrap();
-                    col_writer.close().unwrap();
-                }
-            }
-        }
-    }
-    // close the row group writer after row is written
-    row_group_writer.close().unwrap();
+    writer.write(&packet_record).expect("Writing batch");
 }


### PR DESCRIPTION
Uses the `arrow` feature of the `parquet` crate instead of the low level Parquet file bindings, since it makes optimizing the row group size way easier.

Additionally dependency `arrow-array` is needed for `parquet` crate anyways.